### PR TITLE
🎵Artwork Rendering

### DIFF
--- a/AppleMusicDiscordRPC/Apple Music Discord RPC.xcodeproj/project.pbxproj
+++ b/AppleMusicDiscordRPC/Apple Music Discord RPC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -120,8 +120,9 @@
 		2EF39E01268D912200299C7F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					2EF39E08268D912200299C7F = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -307,7 +308,7 @@
 				CURRENT_PROJECT_VERSION = 8;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 2VZNUT7D2E;
+				DEVELOPMENT_TEAM = Y4V269DARF;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
@@ -336,7 +337,7 @@
 				CURRENT_PROJECT_VERSION = 8;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 2VZNUT7D2E;
+				DEVELOPMENT_TEAM = Y4V269DARF;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;

--- a/AppleMusicDiscordRPC/Modals/DiscordRPCObservable.swift
+++ b/AppleMusicDiscordRPC/Modals/DiscordRPCObservable.swift
@@ -121,11 +121,13 @@ class DiscordRPCObservable: ObservableObject {
                 self.artwork.album = album
                 // if no artworks embbeded to the file, it returns nil so RPCStatusView can render no artwork
                 self.artwork.url = artworks?.first?.data ?? nil
+                
+                self.rpc.setPresence(presence)
             } else {
                 presence.assets.largeImage = "applemusic_large"
+                
+                self.rpc.setPresence(presence)
             }
-            
-            self.rpc.setPresence(presence)
         }
     }
     

--- a/AppleMusicDiscordRPC/Modals/MusicScriptingBridge.swift
+++ b/AppleMusicDiscordRPC/Modals/MusicScriptingBridge.swift
@@ -3,6 +3,7 @@
 // https://github.com/tingraldi/SwiftScripting
 
 import ScriptingBridge
+import SwiftUI
 
 @objc public protocol SBObjectProtocol: NSObjectProtocol {
     func get() -> Any!
@@ -25,15 +26,27 @@ import ScriptingBridge
 
 // MARK: MusicItem
 @objc public protocol MusicItem: SBObjectProtocol {
+    @objc optional func id() -> Int // the id of the item
     @objc optional var name: String { get } // the name of the item
+    @objc optional var persistentID: String { get } // the id of the item as a hexadecimal string. This id does not change over time.
 }
 extension SBObject: MusicItem {}
+
+// MARK: MusicArtwork
+@objc public protocol MusicArtwork: MusicItem {
+    @objc optional var data: NSImage { get } // data for this artwork, in the form of a picture
+    @objc optional var objectDescription: String { get } // description of artwork as a string
+    @objc optional var kind: Int { get } // kind or purpose of this piece of artwork
+    @objc optional var rawData: Data { get } // data for this artwork, in original format
+}
+extension SBObject: MusicArtwork {}
 
 // MARK: MusicTrack
 @objc public protocol MusicTrack: MusicItem {
     @objc optional var album: String { get } // the album name of the track
     @objc optional var artist: String { get } // the artist/source of the track
     @objc optional var finish: Double { get } // the stop time of the track in seconds
+    @objc optional func artworks() -> Array<MusicArtwork>
 }
 extension SBObject: MusicTrack {}
 

--- a/AppleMusicDiscordRPC/Views/RPCStatusView.swift
+++ b/AppleMusicDiscordRPC/Views/RPCStatusView.swift
@@ -13,22 +13,9 @@ struct RPCStatusView: View {
 
     var body: some View {
         HStack {
-            if let artworkURL: String = self.rpcObservable.artwork.url {
-                AsyncImage(url: URL(string: artworkURL)) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .resizable()
-                    case .failure(let error):
-                        self.noArtwork
-                            .onAppear {
-                                print(error)
-                            }
-                    default:
-                        ProgressView()
-                    }
-                }
-                .frame(width: self.artworkSize, height: self.artworkSize)
+            if let artworkURL: NSImage = self.rpcObservable.artwork.url {
+                Image(nsImage: artworkURL).resizable()
+                    .frame(width: self.artworkSize, height: self.artworkSize)
             } else {
                 self.noArtwork
             }


### PR DESCRIPTION
## Added Artwork on RPC Status Bar coming from SBApplication

`MusicTrack` has a method that returns one album cover whenever it is available

## Added new search endpoint

`GET /lookup` is a more reliable source of collecting data, once if you have the album ID, it should be one and only. Once playerInfo moves, if it's a song pulled from Apple Music that is available to buy on iTunes, an `itmss://` url appears that we can pluck album ID

## Improved search URL

searching by `entity=album` returns albums, but it was all over the place. using the `term=\(artist)` and `attribute=artistTerm` we can guarantee that all the data returned is from the specific artists, leaving us to find the right album through the app

## Caveats

* ~while working on this, I removed the condition preventing request/replace a cover from the same album. I'll try to get this sorted out before you get to review this, but as of now every new song is a request to iTunes and the icon flashes on Discord.~ I kept the query, but I fixed the flickering. iTunes allows 20 requests/minute, it shouldn't be a problem for most users.

* you'll need to put your developer id back to build (but you might know that). Opening through Xcode to run/debug forces you to change into your own dev id and I pushed it to you as it was "mine".

